### PR TITLE
Bugfix, TypeError raised when passing ContentType instance

### DIFF
--- a/data_wizard/serializers.py
+++ b/data_wizard/serializers.py
@@ -24,8 +24,8 @@ class ContentTypeIdField(serializers.RelatedField):
         except ContentType.DoesNotExist:
             self.fail('does_not_exist', app_label=app_label, model=model)
 
-    def to_representation(self, content_type_id):
-        ct = ContentType.objects.get(pk=content_type_id)
+    def to_representation(self, content_type):
+        ct = ContentType.objects.get(pk=content_type.pk)
         return '%s.%s' % (ct.app_label, ct.model)
 
 


### PR DESCRIPTION
Fix for:

```
TypeError at /datawizard/
int() argument must be a string, a bytes-like object or a number, not 'ContentType'
```

Serializer passes set of `ContentType` objects to `ContentTypeIdField`:

```
class RunSerializer(serializers.ModelSerializer):
    user = serializers.HiddenField(default=serializers.CurrentUserDefault())
    content_type_id = ContentTypeIdField(queryset=ContentType.objects.all())  <---
```

This object is received by `to_representation` with the name `content_type_id`, although it is the instance. `pk=content_type_id` fails with a `TypeError` as it tries to cast `content_type_id` to an `int` so it can perform the lookup.

```
def to_representation(self, content_type_id):
    ct = ContentType.objects.get(pk=content_type_id)  <---
    return '%s.%s' % (ct.app_label, ct.model)
```

Fixed by passing the PK instead:

```
def to_representation(self, content_type):
    ct = ContentType.objects.get(pk=content_type.pk)
    return '%s.%s' % (ct.app_label, ct.model)
```