### PR TITLE
enable poetry install by adding pyproject.toml and supporting shell script

### DIFF
--- a/docs/overview/setup.md
+++ b/docs/overview/setup.md
@@ -19,7 +19,7 @@ python3 -m pip install data-wizard
 Alternatively you may use poetry to install `data-wizard` in a poetry-managed .venv:
 
 ```bash
-poetry install
+poetry install data-wizard
 ```
 
 ## Initial Configuration

--- a/docs/overview/setup.md
+++ b/docs/overview/setup.md
@@ -16,6 +16,12 @@ Getting Started
 python3 -m pip install data-wizard
 ```
 
+Alternatively you may use poetry to install `data-wizard` in a poetry-managed .venv:
+
+```
+poetry install
+```
+
 ## Initial Configuration
 
 Within a new or existing Django project, add `data_wizard` to your `INSTALLED_APPS`:

--- a/docs/overview/setup.md
+++ b/docs/overview/setup.md
@@ -18,7 +18,7 @@ python3 -m pip install data-wizard
 
 Alternatively you may use poetry to install `data-wizard` in a poetry-managed .venv:
 
-```
+```bash
 poetry install
 ```
 

--- a/install_editable.sh
+++ b/install_editable.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# set -e
+
+# find package name in pyproject.toml:
+# grep -E 'name\s*=\s*["'"'].*['"'"]' pyproject.toml
+
+# assume directory name is same as package name
+PKG_NAME=$(basename $(pwd))
+
+DATA_DIR=.$PKG_NAME-data
+LOGFILE=$DATA_DIR/poetry-build.log
+
+mkdir -p $DATA_DIR
+date >> $LOGFILE
+echo "Making sure pyproject.toml says 'generate-setup-file = true'..." | tee -a $LOGFILE
+sed s/'generate-setup-file = false'/'generate-setup-file = true'/g -i pyproject.toml
+
+pip install poetry
+POETRY_PATH=$(which poetry)
+echo "Found POETRY_PATH=$POETRY_PATH"
+echo "$(poetry --version)"
+
+echo "Building package with 'poetry build -f sdist'..." | tee -a $LOGFILE
+TARFILE=$(poetry build -f sdist | tee -a $LOGFILE | grep -o -E "$PKG_NAME"'-[vabrc0-9.]+[.]tar[.]gz') 
+
+if [[ -n "$TARFILE" ]]; then
+    echo "Built $TARFILE" | tee -a $LOGFILE
+    echo "rm -f setup.py" | tee -a $LOGFILE
+    echo "tar xvz --file=dist/$TARFILE --wildcards '*/setup.py'" | tee -a $LOGFILE
+    rm -f setup.py
+    SETUPFILE=$(tar xvz --strip-component=1 --file=dist/$TARFILE --wildcards '*/setup.py' | tee -a $LOGFILE)
+    if [[ -f "setup.py" ]]; then 
+        echo "Found setup.py so running 'pip install -e .'" | tee -a $LOGFILE
+        pip install -e .
+        echo "Successfully ran 'pip install -e .'"
+    else
+        echo "FAILED: Unable to find a setup.py file."
+    fi
+else
+    echo "FAILED: Unable to build setup.py with poetry for installation with pip."
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.poetry]
+name = "data-wizard"
+version = "2.1.0"
+description = "Interactive web-based wizard for importing structured data into Django models."
+authors = ["S. Andrew Sheppard <andrew@wq.io>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "^3.8"
+
+[tool.poetry.dev-dependencies]
+djangorestframework = "^3.13.1"
+django = "^4.0.6"
+itertable = "^2.1.0"
+natural-keys = "^2.0.0"
+html-json-forms = "1.1.1"
+python-dateutil = "^2.8.2"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+if [ "$CELERY" ]; then
+    celery worker -A tests &
+fi;
+
+python -m django test --settings=tests.settings


### PR DESCRIPTION
* fix issue #40 
* does not fix any tests and has not been fully tested (only runserver on Django >4.0, Python >3.8). The newly added `runtests.sh` fails on `main` with or without this `pyproject.toml` 
* added `poetry install` as 2nd option in `setup.md`
* `runtests.sh` is missing and the one I created is broken (see Issue #41)
